### PR TITLE
fix: allow test label generation for orders

### DIFF
--- a/shipstation/models.py
+++ b/shipstation/models.py
@@ -269,6 +269,7 @@ class ShipStationOrder(ShipStationBase):
     externally_fulfilled: typing.Optional[bool] = None
     externally_fulfilled_by: typing.Optional[str] = None
     label_messages: typing.Optional[str] = None
+    test_label: typing.Optional[bool] = None
 
 
 @attrs(auto_attribs=True)


### PR DESCRIPTION
**Problem:**

While trying to generate a test label for Shipstation orders, the client would error out complaining about insufficient authorizaton.

This was due to the client not applying the test label property before sending the request.
