### PR TITLE
fix: prevent parameter override + add product parameters

### DIFF
--- a/shipstation/api.py
+++ b/shipstation/api.py
@@ -151,10 +151,13 @@ class ShipStation(ShipStationHTTP):
         return ShipStationItem().json(r.text) #TODO: switch to parse float and test deserialization
 
     def list_products(self, parameters: typing.Dict[str, typing.Any] = {}) -> Page:
+        valid_parameters = self._validate_parameters(
+            parameters, PRODUCT_LIST_PARAMETERS
+        )
         return Page(
             type=ShipStationItem,
             key="products",
-            params=parameters,
+            params=valid_parameters,
             call=(self.get, {"endpoint": "/products"}),
         )
 
@@ -213,8 +216,8 @@ class ShipStation(ShipStationHTTP):
         return Page(
             type=ShipStationCustomer,
             key="customers",
-            params=parameters,
-            call=(self.get, {"endpoint": "/customers", "payload": valid_parameters}),
+            params=valid_parameters,
+            call=(self.get, {"endpoint": "/customers"}),
         )
 
     def list_fulfillments(self, parameters: typing.Any = {}) -> Page:
@@ -224,8 +227,8 @@ class ShipStation(ShipStationHTTP):
         return Page(
             type=ShipStationFulfillment,
             key="fulfillments",
-            params=parameters,
-            call=(self.get, {"endpoint": "/fulfillments", "payload": valid_parameters}),
+            params=valid_parameters,
+            call=(self.get, {"endpoint": "/fulfillments"}),
         )
 
     def list_shipments(self, parameters: typing.Any = {}) -> Page:
@@ -235,8 +238,8 @@ class ShipStation(ShipStationHTTP):
         return Page(
             type=ShipStationOrder,
             key="shipments",
-            params=parameters,
-            call=(self.get, {"endpoint": "/shipments", "payload": valid_parameters}),
+            params=valid_parameters,
+            call=(self.get, {"endpoint": "/shipments"}),
         )
 
     # TODO: return shipment label as objects

--- a/shipstation/constants.py
+++ b/shipstation/constants.py
@@ -39,6 +39,22 @@ CONFIRMATION_VALUES = (
     "direct_signature",
 )
 
+# https://www.shipstation.com/docs/api/products/list/
+PRODUCT_LIST_PARAMETERS = (
+    "sku",
+    "name",
+    "product_category_id",
+    "product_type_id",
+    "tag_id",
+    "start_date",
+    "end_date",
+    "show_inactive",
+    "sort_by",
+    "sort_dir",
+    "page",
+    "page_size"
+)
+
 
 # https://www.shipstation.com/developer-api/#/reference/orders/list-orders/list-orders-with-parameters
 ORDER_LIST_PARAMETERS = (

--- a/shipstation/constants.py
+++ b/shipstation/constants.py
@@ -16,6 +16,7 @@ __all__ = [
     "SUBSCRIBE_TO_WEBHOOK_EVENT_OPTIONS",
     "WEIGHT_UNIT_OPTIONS",
     "CREATE_WAREHOUSE_OPTIONS",
+    "PRODUCT_LIST_PARAMETERS",
 ]
 
 # https://www.shipstation.com/developer-api/#/reference/orders/createupdate-order/create/update-order


### PR DESCRIPTION
We faced an issue with requests not properly serializing the parameters before being sent.

In our case, this caused a shipment request to send `create_start_date` instead of `createStartDate`, and the response picked up shipments from all time.

I'm not sure about the original design, but it seems like your `params` argument in the `Page` class overrides any `payload` being set in the `call` argument.

I've fixed it by sending the serialized parameters through `params` instead of `call`.