### PR TITLE
fix: throw Shipstation errors to the user

### DIFF
--- a/shipstation/http.py
+++ b/shipstation/http.py
@@ -37,6 +37,8 @@ class ShipStationHTTP(ShipStationBase):
         if self.debug:
             print(f"GET {r.url}")
             print(json.dumps(r.json(), indent=4, sort_keys=True))
+        if r.is_error:
+            r.raise_for_status()
         return r
 
     def post(self, data: typing.Any = None, endpoint: str = "") -> httpx.Response:
@@ -50,6 +52,8 @@ class ShipStationHTTP(ShipStationBase):
         if self.debug:
             print(f"POST {r.url}")
             print(json.dumps(r.json(), indent=4, sort_keys=True))
+        if r.is_error:
+            r.raise_for_status()
         return r
 
     def put(self, data: typing.Any = None, endpoint: str = "") -> httpx.Response:
@@ -61,8 +65,10 @@ class ShipStationHTTP(ShipStationBase):
             timeout=self.timeout,
         )
         if self.debug:
-            print(f" PUT {r.url}")
+            print(f"PUT {r.url}")
             print(json.dumps(r.json(), indent=4, sort_keys=True))
+        if r.is_error:
+            r.raise_for_status()
         return r
 
     def delete(self, payload: typing.Any = None, endpoint: str = "") -> httpx.Response:
@@ -75,4 +81,6 @@ class ShipStationHTTP(ShipStationBase):
         if self.debug:
             print(f"DELETE {r.url}")
             print(json.dumps(r.json(), indent=4, sort_keys=True))
+        if r.is_error:
+            r.raise_for_status()
         return r

--- a/shipstation/pagination.py
+++ b/shipstation/pagination.py
@@ -25,8 +25,6 @@ class Page:
         if self.params:
             args = {**self.call[1], "payload": self.params}  # type: ignore
         response = f(**args)
-        if response.is_error:
-            response.raise_for_status()
         self.load_results(response)
 
     def load_results(self, response: Response) -> "Page":

--- a/shipstation/pagination.py
+++ b/shipstation/pagination.py
@@ -1,8 +1,8 @@
 import typing
-from decimal import Decimal
-from functools import partial
 
 from attr import attrib, attrs
+from decimal import Decimal
+from functools import partial
 from httpx import Response
 
 from shipstation.base import ShipStationBase
@@ -25,6 +25,8 @@ class Page:
         if self.params:
             args = {**self.call[1], "payload": self.params}  # type: ignore
         response = f(**args)
+        if response.is_error:
+            response.raise_for_status()
         self.load_results(response)
 
     def load_results(self, response: Response) -> "Page":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def mocked_api() -> respx.MockTransport:
         respx_mock.get(
             "/shipments", content=api_data.list_shipments, alias="list_shipments",
         )
-        respx_mock.get("/shipments", alias="list_shipments_500") % Response(500)
+        respx_mock.get("/shipments", alias="list_shipments_error") % Response(500)
         respx_mock.get(
             "/carriers/listservices?carrierCode=stamps_com",
             content=api_data.list_services,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def mocked_api() -> respx.MockTransport:
         respx_mock.get(
             "/shipments", content=api_data.list_shipments, alias="list_shipments",
         )
+        # mocking with an exception: https://lundberg.github.io/respx/guide/#modulo-shortcut
         respx_mock.get("/shipments", alias="list_shipments_error") % Response(500)
         respx_mock.get(
             "/carriers/listservices?carrierCode=stamps_com",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 import respx
+from httpx import Response
 
 import api_data
 from shipstation.api import ShipStation
@@ -69,6 +70,7 @@ def mocked_api() -> respx.MockTransport:
         respx_mock.get(
             "/shipments", content=api_data.list_shipments, alias="list_shipments",
         )
+        respx_mock.get("/shipments", alias="list_shipments_500") % Response(500)
         respx_mock.get(
             "/carriers/listservices?carrierCode=stamps_com",
             content=api_data.list_services,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -220,8 +220,8 @@ def test_list_shipments(ss: ShipStation, mocked_api: respx.MockTransport) -> Non
 
 
 @respx.mock
-def test_list_shipments_500(ss: ShipStation, mocked_api: respx.MockTransport) -> None:
-    request = mocked_api["list_shipments_500"]
+def test_list_shipments_error(ss: ShipStation, mocked_api: respx.MockTransport) -> None:
+    request = mocked_api["list_shipments_error"]
     with pytest.raises(httpx.HTTPStatusError):
         ss.list_shipments()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import os
 from decimal import Decimal
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 
@@ -216,6 +217,13 @@ def test_list_shipments(ss: ShipStation, mocked_api: respx.MockTransport) -> Non
     assert response[0].create_date == datetime.datetime(2015, 6, 29, 14, 29, 28, 583000)
     assert response[0].shipment_cost == Decimal("2.35")
     assert response[0].tracking_number == "9400111899562764298812"
+
+
+@respx.mock
+def test_list_shipments_500(ss: ShipStation, mocked_api: respx.MockTransport) -> None:
+    request = mocked_api["list_shipments_500"]
+    with pytest.raises(httpx.HTTPStatusError):
+        ss.list_shipments()
 
 
 @respx.mock


### PR DESCRIPTION
**Problem:**

If Shipstation throws an error while processing a request, the client fails and suppresses the SS error.

<details>
<summary>Old Traceback</summary>

```python
TypeError: 'NoneType' object is not iterable
  File "rq/worker.py", line 793, in perform_job
    rv = job.perform()
  File "rq/job.py", line 599, in perform
    self._result = self._execute()
  File "rq/job.py", line 605, in _execute
    return self.func(*self.args, **self.kwargs)
  File "frappe/utils/background_jobs.py", line 102, in execute_job
    method(**kwargs)
  File "shipstation_integration/shipments.py", line 63, in list_shipments
    shipments = client.list_shipments(parameters=parameters)
  File "shipstation/api.py", line 242, in list_shipments
    call=(self.get, {"endpoint": "/shipments"}),
  File "<attrs generated init shipstation.pagination.Page>", line 11, in __init__
  File "shipstation/pagination.py", line 28, in __attrs_post_init__
    self.load_results(response)
  File "shipstation/pagination.py", line 33, in load_results
    self.results = [self.type().json(r) for r in results.get(self.key)]
```

</details>

**Fix:**

The client will now detect errors in the response, and raise it to the user so that they can handle it in their application.

<details>
<summary>New Traceback</summary>

```python
Traceback (most recent call last)

~/parsimony/apps/frappe/frappe/commands/utils.py in <module>
---> 8 client.list_shipments(parameters=params)

~/parsimony/env/lib/python3.6/site-packages/shipstation/api.py in list_shipments(self, parameters)
---> 239             call=(self.get, {"endpoint": "/shipments", "payload": valid_parameters}),

<attrs generated init shipstation.pagination.Page> in __init__(self, key, type, call, results, params, page, pages, total, index)
---> 11     self.__attrs_post_init__()

~/parsimony/env/lib/python3.6/site-packages/shipstation/pagination.py in __attrs_post_init__(self)
---> 29             response.raise_for_status()

~/parsimony/env/lib/python3.6/site-packages/httpx/_models.py in raise_for_status(self)
---> 844             raise HTTPError(message, response=self)

HTTPError: 500 Server Error: Internal Server Error for url: https://ssapi.shipstation.com/shipments?storeId=94881&sortBy=CraeteDate
For more information check: https://httpstatuses.com/500
```

</details>